### PR TITLE
Added the ability to use OTP as recovery/validate codes

### DIFF
--- a/authorization_context/main.go
+++ b/authorization_context/main.go
@@ -194,11 +194,14 @@ func (a *AuthorizationContext) WithDefaultOptions() *AuthorizationContext {
 
 	// Setting the default durations into the Options object
 	a.Options = &AuthorizationOptions{
-		ControllerPrefix:         env.ControllerPrefix(),
-		TokenDuration:            env.TokenDuration(),
-		RefreshTokenDuration:     env.RefreshTokenDuration(),
-		VerifyEmailTokenDuration: env.VerifyEmailTokenDuration(),
-		RecoverTokenDuration:     env.RecoverTokenDuration(),
+		ControllerPrefix:           env.ControllerPrefix(),
+		TokenDuration:              env.TokenDuration(),
+		RefreshTokenDuration:       env.RefreshTokenDuration(),
+		VerifyEmailTokenDuration:   env.VerifyEmailTokenDuration(),
+		RecoverTokenDuration:       env.RecoverTokenDuration(),
+		OtpSecret:                  env.OtpSecret(),
+		OptDuration:                env.OtpDefaultDuration(),
+		EmailVerificationProcessor: env.VerifyEmailProcessor(),
 		PasswordRules: PasswordRules{
 			RequiresCapital: env.PasswordValidationRequireCapital(),
 			RequiresSpecial: env.PasswordValidationRequireSpecial(),

--- a/authorization_context/options.go
+++ b/authorization_context/options.go
@@ -5,18 +5,21 @@ import (
 )
 
 type AuthorizationOptions struct {
-	KeyVaultEnabled          bool
-	TokenDuration            int
-	RefreshTokenDuration     int
-	VerifyEmailTokenDuration int
-	RecoverTokenDuration     int
-	SignatureType            encryption.EncryptionKeyType
-	SignatureSize            encryption.EncryptionKeySize
-	PrivateKey               string
-	PublicKey                string
-	KeyId                    string
-	ControllerPrefix         string
-	PasswordRules            PasswordRules
+	KeyVaultEnabled            bool
+	TokenDuration              int
+	RefreshTokenDuration       int
+	VerifyEmailTokenDuration   int
+	RecoverTokenDuration       int
+	OtpSecret                  string
+	OptDuration                int
+	EmailVerificationProcessor string
+	SignatureType              encryption.EncryptionKeyType
+	SignatureSize              encryption.EncryptionKeySize
+	PrivateKey                 string
+	PublicKey                  string
+	KeyId                      string
+	ControllerPrefix           string
+	PasswordRules              PasswordRules
 }
 
 type AuthorizationValidationOptions struct {

--- a/controllers/email_validation.go
+++ b/controllers/email_validation.go
@@ -39,6 +39,9 @@ func (c *AuthorizationControllers) EmailVerificationRequest() controllers.Contro
 			ID:               usr.ID,
 			Email:            usr.Email,
 			EmailVerifyToken: usr.EmailVerifyToken,
+			DisplayName:      usr.DisplayName,
+			FirstName:        usr.FirstName,
+			LastName:         usr.LastName,
 		}
 
 		if err := ctx.NotifySuccess(models.EmailValidationRequest, notifyData); err != nil {

--- a/controllers/otp.go
+++ b/controllers/otp.go
@@ -1,0 +1,36 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/cjlapao/common-go-identity-otp/totp"
+	"github.com/cjlapao/common-go-identity/models"
+	"github.com/cjlapao/common-go-restapi/controllers"
+)
+
+// Configuration Returns the OpenID Oauth configuration endpoint
+func (c *AuthorizationControllers) OtpForEmailValidation() controllers.Controller {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := NewBaseContext(r)
+
+		options := totp.TotpOptions{
+			Period: 5 * 60,
+		}
+
+		code, err := totp.GenerateCode("JBSWY3DPEHPK3PXP", time.Now().UTC(), &options)
+		if err != nil {
+			ctx.Logger.Exception(err, "error generating the totp code")
+			w.WriteHeader(http.StatusInternalServerError)
+			responseErr := models.OAuthErrorResponse{
+				Error:            models.UnknownError,
+				ErrorDescription: "there was unknown error",
+			}
+			json.NewEncoder(w).Encode(responseErr)
+			return
+		}
+
+		json.NewEncoder(w).Encode(code)
+	}
+}

--- a/controllers/password_recovery.go
+++ b/controllers/password_recovery.go
@@ -41,6 +41,9 @@ func (c *AuthorizationControllers) RecoverPasswordRequest() controllers.Controll
 			ID:            usr.ID,
 			Email:         usr.Email,
 			RecoveryToken: usr.RecoveryToken,
+			DisplayName:   usr.DisplayName,
+			FirstName:     usr.FirstName,
+			LastName:      usr.LastName,
 		}
 
 		if err := ctx.NotifySuccess(models.PasswordRecoveryRequest, notificationData); err != nil {

--- a/environment/environment.go
+++ b/environment/environment.go
@@ -27,6 +27,9 @@ const (
 	VALIDATION_PASSWORD_MIN_SIZE_ENV_VAR_NAME         = "identity__validation__password__min_size"
 	VALIDATION_PASSWORD_ALLOW_SPACES_ENV_VAR_NAME     = "identity__validation__password__allow_spaces"
 	VALIDATION_PASSWORD_ALLOWED_SPECIALS_ENV_VAR_NAME = "identity__validation__password__allowed_specials"
+	VERIFY_EMAIL_PROCESSOR_ENV_VAR_NAME               = "identity__verify_email_processor"
+	OTP_DEFAULT_DURATION_ENV_VAR_NAME                 = "identity__otp_default_duration"
+	OTP_SECRET_ENV_VAR_NAME                           = "identity__otp_secret"
 )
 
 var currentEnv *Environment
@@ -37,6 +40,9 @@ type Environment struct {
 	tokenDuration                     int
 	refreshTokenDuration              int
 	verifyEmailTokenDuration          int
+	verifyEmailProcessor              string
+	otpDefaultDuration                int
+	otpSecret                         string
 	recoverTokenDuration              int
 	scope                             string
 	authorizationType                 string
@@ -65,6 +71,9 @@ func New() *Environment {
 		apiPort:                  config.GetString(API_PORT_ENV_VAR_NAME),
 		apiPrefix:                config.GetString(API_PREFIX_ENV_VAR_NAME),
 		controllerPrefix:         config.GetString(CONTROLLER_PREFIX_ENV_VAR_NAME),
+		verifyEmailProcessor:     config.GetString(VERIFY_EMAIL_PROCESSOR_ENV_VAR_NAME),
+		otpSecret:                config.GetString(OTP_SECRET_ENV_VAR_NAME),
+		otpDefaultDuration:       config.GetInt(OTP_DEFAULT_DURATION_ENV_VAR_NAME),
 	}
 
 	// password default config
@@ -248,4 +257,31 @@ func (env *Environment) PasswordValidationAllowedSpecials() string {
 	}
 
 	return env.passwordValidationAllowedSpecials
+}
+
+func (env *Environment) VerifyEmailProcessor() string {
+	if env.verifyEmailProcessor == "" {
+		env.verifyEmailProcessor = "otp"
+	}
+
+	switch env.verifyEmailProcessor {
+	case "otp":
+		return "otp"
+	case "jwt":
+		return "jwt"
+	default:
+		return "otp"
+	}
+}
+
+func (env *Environment) OtpDefaultDuration() int {
+	if env.otpDefaultDuration == 0 {
+		env.otpDefaultDuration = 300
+	}
+
+	return env.otpDefaultDuration
+}
+
+func (env *Environment) OtpSecret() string {
+	return env.otpSecret
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cjlapao/common-go-database v0.0.5
 	github.com/cjlapao/common-go-execution-context v0.0.2
 	github.com/cjlapao/common-go-identity-oauth2 v0.0.6
+	github.com/cjlapao/common-go-identity-otp v0.0.3
 	github.com/cjlapao/common-go-logger v0.0.3
 	github.com/cjlapao/common-go-restapi v0.0.12
 	github.com/google/uuid v1.3.0
@@ -27,6 +28,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cjlapao/common-go-execution-context v0.0.2 h1:8w5PJB73KU0TGa2Ox7gB7Qn
 github.com/cjlapao/common-go-execution-context v0.0.2/go.mod h1:TTd4sgL76Iw8LH45cv2WUARD5fItEs7pzjoObdmgte0=
 github.com/cjlapao/common-go-identity-oauth2 v0.0.6 h1:3OR2QaXlX3gfe0gV90401F3VUEBMxpEwnSqbyCdxbEo=
 github.com/cjlapao/common-go-identity-oauth2 v0.0.6/go.mod h1:s5kDaZCLPGuHUSsp1iS4PVGFx2/DNwD8oBA8o5am5vc=
+github.com/cjlapao/common-go-identity-otp v0.0.3 h1:5u4B9ssCfyjoNbXtIZ/DS8zobM1QBfAbhK5qiZDgeSA=
+github.com/cjlapao/common-go-identity-otp v0.0.3/go.mod h1:FY+WajKeoJl0aitM4fCP36t7I5WhkjOA+b8wQad7jJg=
 github.com/cjlapao/common-go-logger v0.0.3 h1:8HM6u7punpoxLj8hfkAB3wjKlC6xs+CkBjReIynIBK4=
 github.com/cjlapao/common-go-logger v0.0.3/go.mod h1:bF2s2y2as4Fwz2Ox3QTkWw1Y02a07jX5ey8smY5inrU=
 github.com/cjlapao/common-go-restapi v0.0.12 h1:71VGcwub8EeqchBTXCwYH2w8BpkRfQZGTZ0rXUFL3Rs=
@@ -54,6 +56,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=

--- a/main.go
+++ b/main.go
@@ -57,6 +57,8 @@ func WithAuthentication(l *restapi.HttpListener, context interfaces.UserContextA
 	if authCtx != nil {
 		defaultAuthControllers := controllers.NewAuthorizationControllers(context)
 
+		l.AddController(defaultAuthControllers.OtpForEmailValidation(), http_helper.JoinUrl(authCtx.Options.ControllerPrefix, "otp"), "GET")
+
 		l.AddController(defaultAuthControllers.Token(), http_helper.JoinUrl(authCtx.Options.ControllerPrefix, "token"), "POST")
 		l.AddController(defaultAuthControllers.Token(), http_helper.JoinUrl(authCtx.Options.ControllerPrefix, "{tenantId}", "token"), "POST")
 


### PR DESCRIPTION
# Description

Added the ability to use OTP as recovery codes

## Type of change

- [x] Documentation Change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works
